### PR TITLE
feat: API for Node child_with_descendant

### DIFF
--- a/crates/tree-sitter-facade/src/node.rs
+++ b/crates/tree-sitter-facade/src/node.rs
@@ -33,6 +33,11 @@ mod native {
         }
 
         #[inline]
+        pub fn child_with_descendant(&self, descendant: Self) -> Option<Self> {
+            self.inner.child_with_descendant(descendant.inner).map(Into::into)
+        }
+
+        #[inline]
         pub fn child_count(&self) -> u32 {
             u32::try_from(self.inner.child_count()).unwrap()
         }
@@ -320,6 +325,11 @@ mod wasm {
             let field_name = field_name.as_ref();
             let field_name = unsafe { std::str::from_utf8_unchecked(field_name) };
             self.inner.child_for_field_name(field_name).map(Into::into)
+        }
+
+        #[inline]
+        pub fn child_with_descendant(&self, descendant: Self) -> Option<Self> {
+            self.inner.child_with_descendant(descendant.inner).map(Into::into)
         }
 
         #[inline]

--- a/crates/web-tree-sitter-sg/src/lib.rs
+++ b/crates/web-tree-sitter-sg/src/lib.rs
@@ -679,6 +679,9 @@ extern {
     #[wasm_bindgen(method, js_name = childForFieldName)]
     pub fn child_for_field_name(this: &SyntaxNode, field_name: &str) -> Option<SyntaxNode>;
 
+    #[wasm_bindgen(method, js_name = childWithDescendant)]
+    pub fn child_with_descendant(this: &SyntaxNode, descendant: &SyntaxNode) -> Option<SyntaxNode>;
+
     #[wasm_bindgen(method, js_name = descendantForIndex)]
     pub fn descendant_for_index(this: &SyntaxNode, index: u32) -> Option<SyntaxNode>;
 

--- a/crates/web-tree-sitter-sg/tests/node/syntax_node.rs
+++ b/crates/web-tree-sitter-sg/tests/node/syntax_node.rs
@@ -370,6 +370,18 @@ async fn child_for_field_name() {
 }
 
 #[wasm_bindgen_test]
+async fn child_with_descendant() {
+    async fn inner() -> Result<(), JsValue> {
+        TreeSitter::init().await?;
+        let node = crate::util::syntax_node::make().await?.unwrap();
+        let descendant = crate::util::syntax_node::make().await?.unwrap();
+        let _ = node.child_with_descendant(&descendant);
+        Ok(())
+    }
+    assert!(inner().await.is_ok());
+}
+
+#[wasm_bindgen_test]
 async fn descendant_for_index() {
     async fn inner() -> Result<(), JsValue> {
         TreeSitter::init().await?;


### PR DESCRIPTION
This commit provides access to the `child_with_descendant` node function, allowing for more efficient searches for, e.g., nodes containing certain ancestors