### PR TITLE
chore: Upgrade tree-sitter to 0.25.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ac5ea5e7f2f1700842ec071401010b9c59bf735295f6e9fa079c3dc035b167"
+checksum = "69aff09fea9a41fb061ae6b206cb87cac1b8db07df31be3ba271fbc26760f213"
 dependencies = [
  "cc",
  "regex",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-facade-sg"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "js-sys",
  "tree-sitter",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "web-tree-sitter-sg"
-version = "0.25.3"
+version = "0.25.4"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 lto = true
 
 [workspace.package]
-version = "0.25.3"
+version = "0.25.4"
 authors = ["Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>"]
 edition = "2021"
 license = "MIT"
@@ -20,6 +20,6 @@ readme = "README.md"
 
 
 [workspace.dependencies]
-web-tree-sitter-sg = { path = "crates/web-tree-sitter-sg", version = "0.25.3" }
-tree-sitter = { version = "0.25.3" }
+web-tree-sitter-sg = { path = "crates/web-tree-sitter-sg", version = "0.25.4" }
+tree-sitter = { version = "0.25.4" }
 tree-sitter-language = { version = "0.1" }

--- a/crates/tree-sitter-facade/src/parser.rs
+++ b/crates/tree-sitter-facade/src/parser.rs
@@ -283,8 +283,7 @@ mod wasm {
 
         #[inline]
         pub fn set_language(&mut self, language: &Language) -> Result<(), LanguageError> {
-            let language = Some(&language.inner);
-            self.inner.set_language(language).map_err(Into::into)
+            self.inner.set_language(&language.inner).map_err(Into::into)
         }
 
         #[inline]

--- a/crates/web-tree-sitter-sg/src/lib.rs
+++ b/crates/web-tree-sitter-sg/src/lib.rs
@@ -897,7 +897,7 @@ extern {
     pub fn reset(this: &Parser);
 
     #[wasm_bindgen(catch, method, js_name = setLanguage)]
-    pub fn set_language(this: &Parser, language: Option<&Language>) -> Result<(), LanguageError>;
+    pub fn set_language(this: &Parser, language: &Language) -> Result<(), LanguageError>;
 
     #[wasm_bindgen(method, js_name = setLogger)]
     pub fn set_logger(this: &Parser, logger: Option<&Logger>);

--- a/crates/web-tree-sitter-sg/src/lib.rs
+++ b/crates/web-tree-sitter-sg/src/lib.rs
@@ -4,7 +4,7 @@
 
 use core::cell::RefCell;
 use js_sys::{Array, Error, Function, JsString, Object, Promise, Reflect, Uint8Array};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::{JsCast, prelude::*};
 use wasm_bindgen_futures::JsFuture;
 
 trait JsValueExt {
@@ -41,7 +41,7 @@ thread_local! {
 pub struct TreeSitter;
 
 impl TreeSitter {
-    pub async fn init() -> Result<(), JsError> {
+    pub async fn init(locate_file: Option<Function>) -> Result<(), JsError> {
         #![allow(non_snake_case)]
 
         // Exit early if `web-tree-sitter` is already initialized
@@ -49,18 +49,18 @@ impl TreeSitter {
             return Ok(());
         }
 
-        JsFuture::from(Parser::init()).await.lift_error()?;
+        if let Some(locate_file) = locate_file {
+            let options = Object::new();
+            Reflect::set(&options, &"locateFile".into(), &locate_file.into()).unwrap();
+            JsFuture::from(Parser::init(Some(&options))).await.lift_error()?;
+        } else {
+            JsFuture::from(Parser::init(None)).await.lift_error()?;
+        }
 
         // Set `web-tree-sitter` to initialized
         TREE_SITTER_INITIALIZED.with(|cell| cell.replace(true));
 
         Ok(())
-    }
-
-    fn init_guard() {
-        if !TREE_SITTER_INITIALIZED.with(|cell| *cell.borrow()) {
-            wasm_bindgen::throw_str("TreeSitter::init must be called to initialize the library");
-        }
     }
 }
 
@@ -154,7 +154,7 @@ extern {
     fn delete(this: &LoggerParams, val: &JsString);
 }
 
-#[wasm_bindgen(module="web-tree-sitter")]
+#[wasm_bindgen(module = "web-tree-sitter")]
 extern {
     #[derive(Clone, Debug, PartialEq)]
     pub type Language;
@@ -204,7 +204,6 @@ extern {
 
 impl Language {
     pub async fn load_bytes(bytes: &Uint8Array) -> Result<Language, LanguageError> {
-        TreeSitter::init_guard();
         JsFuture::from(Language::__load_bytes(bytes))
             .await
             .map(JsCast::unchecked_into)
@@ -212,7 +211,6 @@ impl Language {
     }
 
     pub async fn load_path(path: &str) -> Result<Language, LanguageError> {
-        TreeSitter::init_guard();
         JsFuture::from(Language::__load_path(path))
             .await
             .map(JsCast::unchecked_into)
@@ -292,8 +290,7 @@ impl Default for Point {
     }
 }
 
-impl Eq for Point {
-}
+impl Eq for Point {}
 
 impl std::hash::Hash for Point {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -538,8 +535,7 @@ impl Default for Range {
     }
 }
 
-impl Eq for Range {
-}
+impl Eq for Range {}
 
 impl std::hash::Hash for Range {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -743,8 +739,7 @@ impl PartialEq<SyntaxNode> for SyntaxNode {
     }
 }
 
-impl Eq for SyntaxNode {
-}
+impl Eq for SyntaxNode {}
 
 impl std::hash::Hash for SyntaxNode {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -850,14 +845,14 @@ extern {
     pub fn reset(this: &TreeCursor, node: &SyntaxNode);
 }
 
-#[wasm_bindgen(module="web-tree-sitter")]
+#[wasm_bindgen(module = "web-tree-sitter")]
 extern {
     #[derive(Clone, Debug)]
     pub type Parser;
 
     // Static Methods
     #[wasm_bindgen(static_method_of = Parser)]
-    pub fn init() -> Promise;
+    pub fn init(options: Option<&Object>) -> Promise;
 
     // Constructor
 
@@ -905,7 +900,6 @@ extern {
 
 impl Parser {
     pub fn new() -> Result<Parser, ParserError> {
-        TreeSitter::init_guard();
         let result = Parser::__new()?;
         Ok(result)
     }


### PR DESCRIPTION
We're working on the new version of @codemod-com's CLI that uses ast-grep to 0.38.2, but we're patching tree-sitter to use this facade still. The version mismatch is a blocker for this upgrade.